### PR TITLE
iOS modifications for cmake defaults

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -274,7 +274,7 @@ if (PXR_BUILD_IMAGING)
         endif()
     endif()
     # --Opensubdiv
-    set(OPENSUBDIV_USE_GPU ${PXR_ENABLE_GL_SUPPORT})
+    set(OPENSUBDIV_USE_GPU (${PXR_ENABLE_GL_SUPPORT} OR APPLEIOS))
     find_package(OpenSubdiv 3 REQUIRED)
     # --Ptex
     if (PXR_ENABLE_PTEX_SUPPORT)
@@ -294,6 +294,17 @@ if (PXR_BUILD_IMAGING)
     # --Embree
     if (PXR_BUILD_EMBREE_PLUGIN)
         find_package(Embree REQUIRED)
+    endif()
+    # --Apple
+    if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        FIND_LIBRARY(METAL_LIBRARY Metal)
+        if (APPLEIOS)
+            FIND_LIBRARY(UIKIT_LIBRARY UIKit)
+            FIND_LIBRARY(APPUIKIT_LIBRARY UIKit)
+        else()
+            FIND_LIBRARY(APPKIT_LIBRARY AppKit)
+            FIND_LIBRARY(APPUIKIT_LIBRARY AppKit)
+        endif()
     endif()
 endif()
 

--- a/cmake/defaults/clangdefaults.cmake
+++ b/cmake/defaults/clangdefaults.cmake
@@ -26,6 +26,14 @@ include(gccclangshareddefaults)
 
 set(_PXR_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS}")
 
+if (APPLE)
+    _disable_warning("comma")
+    _disable_warning("deprecated-register")
+    _disable_warning("documentation")
+    _disable_warning("deprecated-declarations")
+    _disable_warning("documentation-deprecated-sync")
+endif()
+
 # clang annoyingly warns about the -pthread option if it's only linking.
 if(CMAKE_USE_PTHREADS_INIT)
     _disable_warning("unused-command-line-argument")


### PR DESCRIPTION
### Description of Change(s)
- Suppresses certain warnings in the log that become more pronounced during iOS building
- Configures opensubdiv usage of GPU for building and finds certain libraries for the whole build


<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
