### PR TITLE
iOS build script - Only copy boost header

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -719,6 +719,11 @@ def InstallBoost_Helper(context, force, buildArgs):
 
     with CurrentWorkingDirectory(DownloadURL(BOOST_URL, context, force, 
                                              dontExtract=dontExtract)):
+        #try just to point to headers
+        if context.targetIos:
+            shutil.copytree("boost",
+                            '{instDir}/include/boost'.format(instDir=context.instDir))
+            return
         if Windows():
             bootstrap = "bootstrap.bat"
         else:


### PR DESCRIPTION
### Description of Change(s)
- When building on iOS, as we don't use boost, we can simply copy the headers to have a successful build script routine

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
